### PR TITLE
Fix issue where it does not capture signature on desktop browsers

### DIFF
--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -445,12 +445,12 @@ function SignaturePad (selector, options) {
     clearCanvas()
 
     canvas.each(function () {
-      this.ontouchstart = function (e) {
+      this.addEventListener('touchstart', function(e) {
         e.preventDefault()
         mouseButtonDown = true
         initDrawEvents(e)
         startDrawing(e, this)
-      }
+      })
     })
 
     canvas.bind('mousedown.signaturepad', function (e) {


### PR DESCRIPTION
Issue: when trying to sign in the box, it just add dots, as opposed to a continuous line. 
The issue happens on [Chrome 73.0.3683.86 (Official Build) (64-bit), Opera 58.0.3135.107, Edge], Firefox 66.0.1 (64-bit) works very well.
This fix fixes the issue for [Chrome, Opera], however it doesn't fix it for Edge. and still works for Firefox. also tested on [Android Chrome, Android Opera Touch]
Explanation: There is a problem with ```this.ontouchstart = function (e) ``` doesn't appear to function well, however ```eddEventListener('touchstart', function(e)``` does work