### PR TITLE
Remove event listener `touchstart` after adding it.

### DIFF
--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -430,7 +430,7 @@ function SignaturePad (selector, options) {
       })
     }
   }
-  function startTouchDrawing {
+  function startTouchDrawing(e) {
       e.preventDefault()
       mouseButtonDown = true
       initDrawEvents(e)

--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -368,8 +368,7 @@ function SignaturePad (selector, options) {
         // this.removeEventListener('MSPointerCancel', stopDrawingWrapper)
         // this.removeEventListener('MSPointerMove', drawLine)
       }
-
-
+       })
     $(document).unbind('mouseup.signaturepad')
     canvas.unbind('mousedown.signaturepad')
     canvas.unbind('mousemove.signaturepad')

--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -363,14 +363,12 @@ function SignaturePad (selector, options) {
         this.removeEventListener('touchend', stopDrawingWrapper)
         this.removeEventListener('touchcancel', stopDrawingWrapper)
         this.removeEventListener('touchmove', drawLine)
+        this.removeEventListener('touchstart', touchStartProcedure)
         // this.removeEventListener('MSPointerUp', stopDrawingWrapper)
         // this.removeEventListener('MSPointerCancel', stopDrawingWrapper)
         // this.removeEventListener('MSPointerMove', drawLine)
       }
 
-      if (this.ontouchstart)
-        this.ontouchstart = null;
-    })
 
     $(document).unbind('mouseup.signaturepad')
     canvas.unbind('mousedown.signaturepad')
@@ -429,11 +427,17 @@ function SignaturePad (selector, options) {
       })
 
       canvas.each(function () {
-        this.ontouchstart = null
+        this.removeEventListener('touchstart', touchStartProcedure)
       })
     }
   }
+  function touchStartProcedure(e) {
+      e.preventDefault()
+      mouseButtonDown = true
+      initDrawEvents(e)
+      startDrawing(e, this)
 
+  }
   /**
    * Triggers the abilities to draw on the canvas
    * Sets up mouse/touch events, hides and shows descriptions and sets current classes
@@ -445,12 +449,7 @@ function SignaturePad (selector, options) {
     clearCanvas()
 
     canvas.each(function () {
-      this.addEventListener('touchstart', function(e) {
-        e.preventDefault()
-        mouseButtonDown = true
-        initDrawEvents(e)
-        startDrawing(e, this)
-      })
+        this.addEventListener('touchstart', touchStartProcedure)
     })
 
     canvas.bind('mousedown.signaturepad', function (e) {

--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -363,7 +363,7 @@ function SignaturePad (selector, options) {
         this.removeEventListener('touchend', stopDrawingWrapper)
         this.removeEventListener('touchcancel', stopDrawingWrapper)
         this.removeEventListener('touchmove', drawLine)
-        this.removeEventListener('touchstart', touchStartProcedure)
+        this.removeEventListener('touchstart', startTouchDrawing)
         // this.removeEventListener('MSPointerUp', stopDrawingWrapper)
         // this.removeEventListener('MSPointerCancel', stopDrawingWrapper)
         // this.removeEventListener('MSPointerMove', drawLine)
@@ -426,11 +426,11 @@ function SignaturePad (selector, options) {
       })
 
       canvas.each(function () {
-        this.removeEventListener('touchstart', touchStartProcedure)
+        this.removeEventListener('touchstart', startTouchDrawing)
       })
     }
   }
-  function touchStartProcedure(e) {
+  function startTouchDrawing {
       e.preventDefault()
       mouseButtonDown = true
       initDrawEvents(e)
@@ -448,7 +448,7 @@ function SignaturePad (selector, options) {
     clearCanvas()
 
     canvas.each(function () {
-        this.addEventListener('touchstart', touchStartProcedure)
+        this.addEventListener('touchstart', startTouchDrawing)
     })
 
     canvas.bind('mousedown.signaturepad', function (e) {


### PR DESCRIPTION
- Issue: when you start drawing by mouse and change to drawing by touch , the mouse button stay triggered. causing the undesired drawing on the canvas.

- Fix: Remove event listener `touchstart` after adding it.

- Explanation: After changing from `this.ontouchstart` to `this.addEventListener('touchstart')`. we should replace `this.ontouchstart = null;` by `this.removeEventListener('touchstart', touchStartProcedure)`