### PR TITLE
Avoid near infinite loops optimizing the typeit font size

### DIFF
--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -528,14 +528,14 @@ function SignaturePad (selector, options) {
     }
 
     if (typeItNumChars > oldLength && typed.outerWidth() > element.width) {
-      while (typed.outerWidth() > element.width) {
+      while (typeItCurrentFontSize > 4 && typed.outerWidth() > element.width) {
         typeItCurrentFontSize--
         typed.css('font-size', typeItCurrentFontSize + 'px')
       }
     }
 
     if (typeItNumChars < oldLength && typed.outerWidth() + edgeOffset < element.width && typeItCurrentFontSize < typeItDefaultFontSize) {
-      while (typed.outerWidth() + edgeOffset < element.width && typeItCurrentFontSize < typeItDefaultFontSize) {
+      while (typeItCurrentFontSize < 512 && typed.outerWidth() + edgeOffset < element.width && typeItCurrentFontSize < typeItDefaultFontSize) {
         typeItCurrentFontSize++
         typed.css('font-size', typeItCurrentFontSize + 'px')
       }


### PR DESCRIPTION
Please note that I've chosen arbitrarily small and large limits to avoid the near infinite loops. I hope that these are suitable. If not, I can adjust to whatever is recommended.